### PR TITLE
Fix: Force wss:// protocol for Archipelago connection

### DIFF
--- a/src/archipelago/base_client.py
+++ b/src/archipelago/base_client.py
@@ -29,7 +29,7 @@ class ArchipelagoClient(ABC) :
     
     async def connect(self) :
         self.ap_connection = await connect(
-            f"ws://{self.client_url}:{self.client_port}",
+            f"wss://{self.client_url}:{self.client_port}",
             max_size=None
         )
         


### PR DESCRIPTION
Bonjour ! 
J'ai installé le bot sur mon serveur et j'ai remarqué que la connexion aux serveurs officiels d'Archipelago (archipelago.gg) échouait (PlayerDB restait à 0).  C'est parce que le serveur exige désormais le protocole sécurisé wss:// au lieu de ws://.

Solution apportée :
Ce correctif passe l'URI de connexion en wss:// dans base_client.py afin de supporter les connexions sécurisées imposées par Archipelago.